### PR TITLE
Another attempt at making Rubocop + Rspec play nice with CI

### DIFF
--- a/spec/lint/rubocop_spec.rb
+++ b/spec/lint/rubocop_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'Branch changes have correct syntax' do
   let(:current_sha) { `git rev-parse --verify HEAD`.strip! }
   let(:files)       { `git diff master #{current_sha} --name-only | grep .rb` }
-  let(:report)      { `rubocop #{files.tr("\n", ' ')}` }
+  let(:report)      { `bundle exec rubocop #{files.tr("\n", ' ')}` }
 
   it 'makes Rubocop happy' do
     expect(report).not_to match(/Offenses/)


### PR DESCRIPTION
Calling `bundle exec rubocop` instead of `rubocop`